### PR TITLE
Add 'all' item in adressbook overlay to view contacts of all categories

### DIFF
--- a/sendtocategory/content/addressbook/addressbook_overlay.js
+++ b/sendtocategory/content/addressbook/addressbook_overlay.js
@@ -32,7 +32,18 @@ jbCatMan.updateCategoryList = function () {
   categoriesList.clearSelection();
   for (let i=categoriesList.getRowCount(); i>0; i--) {
     categoriesList.removeItemAt(i-1);            
-  }                  
+  }             
+
+  // add listitem to view contacts of all categories
+  let newListItem = document.createElement("listitem");
+  newListItem.setAttribute("id", "");
+  let categoryName = document.createElement("listcell");
+  categoryName.setAttribute("label", jbCatMan.locale.viewAllCategories);
+  newListItem.appendChild(categoryName);  
+  let categorySize = document.createElement("listcell");
+  categorySize.setAttribute("label", "");
+  newListItem.appendChild(categorySize);            
+  categoriesList.appendChild(newListItem);
   
   //add all categories from the updated/merged array to the category listbox
   for (let i = 0; i < jbCatMan.data.categoryList.length; i++) {

--- a/sendtocategory/content/addressbook/addressbook_overlay.xul
+++ b/sendtocategory/content/addressbook/addressbook_overlay.xul
@@ -31,6 +31,7 @@
         jbCatMan.locale.menuBulk = "&sendtocategory.bulkeditMenu.label;";
 
         jbCatMan.locale.prefixForPeopleSearch = "&sendtocategory.category.label;";
+        jbCatMan.locale.viewAllCategories = "&sendtocategory.category.all;";
     </script>
 
     <popupset>

--- a/sendtocategory/content/category_tools.js
+++ b/sendtocategory/content/category_tools.js
@@ -180,8 +180,13 @@ jbCatMan.doCategorySearch = function () {
     }        
   }
 
-  //SetAbView(GetSelectedDirectory() + "?" + "(or" + searchQuery + ")");
-  SetAbView(abURI + "?" + "(or" + searchQuery + ")");
+  // view all contatcs
+  if ( jbCatMan.data.selectedCategory == "" ) {
+    SetAbView(abURI);
+  } else {
+    //SetAbView(GetSelectedDirectory() + "?" + "(or" + searchQuery + ")");
+    SetAbView(abURI + "?" + "(or" + searchQuery + ")");
+  }
   if (document.getElementById("CardViewBox") != null && jbCatMan.data.selectedCategory in jbCatMan.data.foundCategories) {
     SelectFirstCard();  
   }

--- a/sendtocategory/locale/de-DE/catman.dtd
+++ b/sendtocategory/locale/de-DE/catman.dtd
@@ -2,6 +2,7 @@
 
 <!ENTITY sendtocategory.foundcategories.label "Gefundene Kategorien">
 <!ENTITY sendtocategory.category.label "Kategorie">
+<!ENTITY sendtocategory.category.all "Alle">
 <!ENTITY sendtocategory.name.label "Name">
 
 <!ENTITY sendtocategory.categoryfilter.label "Kategoriefilter ...">

--- a/sendtocategory/locale/en-US/catman.dtd
+++ b/sendtocategory/locale/en-US/catman.dtd
@@ -2,6 +2,7 @@
 
 <!ENTITY sendtocategory.foundcategories.label "Found categories:">
 <!ENTITY sendtocategory.category.label "category">
+<!ENTITY sendtocategory.category.all "All">
 <!ENTITY sendtocategory.name.label "name">
 
 <!ENTITY sendtocategory.categoryfilter.label "Categories ...">


### PR DESCRIPTION
This small feature might be useful to reset the current category selection. 

It just adds an extra item at the top of the categorie list in address book overlay with the label "All". 
For example also the OwnCloud Contacts App does it like this.

It might be also good to view the category size as all members in the selected addressbook. But i wasn't able to get this for the moment...
