### PR TITLE
fix: clone the contact when creating all-contacts addressBook

### DIFF
--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -54,7 +54,7 @@
         "message": "Diese Kategorie umbenennen oder verschieben"
     },
     "menu.contact.context.add_to_category": {
-        "message": "Zu '$CATEGORY$' hinzufügen",
+        "message": "Kontakt zu '$CATEGORY$' hinzufügen",
         "placeholders": {
             "category": {
                 "content": "$1"
@@ -76,7 +76,7 @@
         "message": "Kategorien dieses Kontakts verwalten"
     },
     "menu.contact.context.remove_from_category": {
-        "message": "Aus '$CATEGORY$' entfernen",
+        "message": "Kontakt aus '$CATEGORY$' entfernen",
         "placeholders": {
             "category": {
                 "content": "$1"
@@ -84,7 +84,7 @@
         }
     },
     "menu.contact.context.remove_from_category_recursively": {
-        "message": "Aus '$CATEGORY$' und allen Unterkategorien entfernen",
+        "message": "Kontakt aus '$CATEGORY$' und allen Unterkategorien entfernen",
         "placeholders": {
             "category": {
                 "content": "$1"

--- a/src/_locales/en-US/messages.json
+++ b/src/_locales/en-US/messages.json
@@ -54,7 +54,7 @@
         "message": "Rename or move this category"
     },
     "menu.contact.context.add_to_category": {
-        "message": "Add to '$CATEGORY$'",
+        "message": "Add contact to '$CATEGORY$'",
         "placeholders": {
             "category": {
                 "content": "$1"
@@ -76,7 +76,7 @@
         "message": "Manage categories of this contact"
     },
     "menu.contact.context.remove_from_category": {
-        "message": "Remove from '$CATEGORY$'",
+        "message": "Remove contact from '$CATEGORY$'",
         "placeholders": {
             "category": {
                 "content": "$1"
@@ -84,7 +84,7 @@
         }
     },
     "menu.contact.context.remove_from_category_recursively": {
-        "message": "Remove from '$CATEGORY$' and all its sub-categories",
+        "message": "Remove contact from '$CATEGORY$' and all its sub-categories",
         "placeholders": {
             "category": {
                 "content": "$1"

--- a/src/_locales/es-AR/messages.json
+++ b/src/_locales/es-AR/messages.json
@@ -54,7 +54,7 @@
         "message": "Rename or move this category"
     },
     "menu.contact.context.add_to_category": {
-        "message": "Add to '$CATEGORY$'",
+        "message": "Add contact to '$CATEGORY$'",
         "placeholders": {
             "category": {
                 "content": "$1"
@@ -76,7 +76,7 @@
         "message": "Manage categories of this contact"
     },
     "menu.contact.context.remove_from_category": {
-        "message": "Remove from '$CATEGORY$'",
+        "message": "Remove contact from '$CATEGORY$'",
         "placeholders": {
             "category": {
                 "content": "$1"
@@ -84,7 +84,7 @@
         }
     },
     "menu.contact.context.remove_from_category_recursively": {
-        "message": "Remove from '$CATEGORY$' and all its sub-categories",
+        "message": "Remove contact from '$CATEGORY$' and all its sub-categories",
         "placeholders": {
             "category": {
                 "content": "$1"

--- a/src/_locales/es-ES/messages.json
+++ b/src/_locales/es-ES/messages.json
@@ -54,7 +54,7 @@
         "message": "Rename or move this category"
     },
     "menu.contact.context.add_to_category": {
-        "message": "Add to '$CATEGORY$'",
+        "message": "Add contact to '$CATEGORY$'",
         "placeholders": {
             "category": {
                 "content": "$1"
@@ -76,7 +76,7 @@
         "message": "Manage categories of this contact"
     },
     "menu.contact.context.remove_from_category": {
-        "message": "Remove from '$CATEGORY$'",
+        "message": "Remove contact from '$CATEGORY$'",
         "placeholders": {
             "category": {
                 "content": "$1"
@@ -84,7 +84,7 @@
         }
     },
     "menu.contact.context.remove_from_category_recursively": {
-        "message": "Remove from '$CATEGORY$' and all its sub-categories",
+        "message": "Remove contact from '$CATEGORY$' and all its sub-categories",
         "placeholders": {
             "category": {
                 "content": "$1"

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -54,7 +54,7 @@
         "message": "Rename or move this category"
     },
     "menu.contact.context.add_to_category": {
-        "message": "Add to '$CATEGORY$'",
+        "message": "Add contact to '$CATEGORY$'",
         "placeholders": {
             "category": {
                 "content": "$1"
@@ -76,7 +76,7 @@
         "message": "Manage categories of this contact"
     },
     "menu.contact.context.remove_from_category": {
-        "message": "Remove from '$CATEGORY$'",
+        "message": "Remove contact from '$CATEGORY$'",
         "placeholders": {
             "category": {
                 "content": "$1"
@@ -84,7 +84,7 @@
         }
     },
     "menu.contact.context.remove_from_category_recursively": {
-        "message": "Remove from '$CATEGORY$' and all its sub-categories",
+        "message": "Remove contact from '$CATEGORY$' and all its sub-categories",
         "placeholders": {
             "category": {
                 "content": "$1"

--- a/src/_locales/nl/messages.json
+++ b/src/_locales/nl/messages.json
@@ -54,7 +54,7 @@
         "message": "Rename or move this category"
     },
     "menu.contact.context.add_to_category": {
-        "message": "Add to '$CATEGORY$'",
+        "message": "Add contact to '$CATEGORY$'",
         "placeholders": {
             "category": {
                 "content": "$1"
@@ -76,7 +76,7 @@
         "message": "Manage categories of this contact"
     },
     "menu.contact.context.remove_from_category": {
-        "message": "Remove from '$CATEGORY$'",
+        "message": "Remove contact from '$CATEGORY$'",
         "placeholders": {
             "category": {
                 "content": "$1"
@@ -84,7 +84,7 @@
         }
     },
     "menu.contact.context.remove_from_category_recursively": {
-        "message": "Remove from '$CATEGORY$' and all its sub-categories",
+        "message": "Remove contact from '$CATEGORY$' and all its sub-categories",
         "placeholders": {
             "category": {
                 "content": "$1"

--- a/src/_locales/pt-BR/messages.json
+++ b/src/_locales/pt-BR/messages.json
@@ -54,7 +54,7 @@
         "message": "Rename or move this category"
     },
     "menu.contact.context.add_to_category": {
-        "message": "Add to '$CATEGORY$'",
+        "message": "Add contact to '$CATEGORY$'",
         "placeholders": {
             "category": {
                 "content": "$1"
@@ -76,7 +76,7 @@
         "message": "Manage categories of this contact"
     },
     "menu.contact.context.remove_from_category": {
-        "message": "Remove from '$CATEGORY$'",
+        "message": "Remove contact from '$CATEGORY$'",
         "placeholders": {
             "category": {
                 "content": "$1"
@@ -84,7 +84,7 @@
         }
     },
     "menu.contact.context.remove_from_category_recursively": {
-        "message": "Remove from '$CATEGORY$' and all its sub-categories",
+        "message": "Remove contact from '$CATEGORY$' and all its sub-categories",
         "placeholders": {
             "category": {
                 "content": "$1"

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -54,7 +54,7 @@
         "message": "Rename or move this category"
     },
     "menu.contact.context.add_to_category": {
-        "message": "Add to '$CATEGORY$'",
+        "message": "Add contact to '$CATEGORY$'",
         "placeholders": {
             "category": {
                 "content": "$1"
@@ -76,7 +76,7 @@
         "message": "Manage categories of this contact"
     },
     "menu.contact.context.remove_from_category": {
-        "message": "Remove from '$CATEGORY$'",
+        "message": "Remove contact from '$CATEGORY$'",
         "placeholders": {
             "category": {
                 "content": "$1"
@@ -84,7 +84,7 @@
         }
     },
     "menu.contact.context.remove_from_category_recursively": {
-        "message": "Remove from '$CATEGORY$' and all its sub-categories",
+        "message": "Remove contact from '$CATEGORY$' and all its sub-categories",
         "placeholders": {
             "category": {
                 "content": "$1"

--- a/src/background/cacher.mjs
+++ b/src/background/cacher.mjs
@@ -2,12 +2,15 @@ import {
   AddressBook,
   registerCacheUpdateCallback,
 } from "../modules/cache/index.mjs";
+import { printToConsole } from "../modules/utils.mjs";
 
 async function storeCache(addressBooks) {
   await browser.storage.local.set({ addressBooks });
 }
 
-console.info("Populating cache...");
+// This needs to be awaited only once, all following calls in this window are
+// synchronous.
+await printToConsole.info("Populating cache...");
 
 // Disable action buttons while cache is being populated.
 browser.browserAction.disable();
@@ -37,7 +40,8 @@ let addressBooks = new Map(abValues.map((ab) => [ab.id, ab]));
 // removes all additional prototypes of our AddressBook and Category classes.
 await storeCache(addressBooks);
 
-console.info("Done populating cache!");
+printToConsole.log(addressBooks);
+printToConsole.info("Done populating cache!");
 
 // Register listener to update cache on backend changes.
 registerCacheUpdateCallback(addressBooks, storeCache)

--- a/src/modules/cache/addressbook.mjs
+++ b/src/modules/cache/addressbook.mjs
@@ -30,7 +30,7 @@ export class AddressBook {
   static fromAllContacts(addressBooks, name) {
     let contacts = new Map();
     for (const ab of addressBooks) {
-      ab.contacts.forEach((contact, id) => contacts.set(id, structuredClone(contact)));
+      ab.contacts.forEach((contact, id) => contacts.set(id, contact));
     }
     let ret = new AddressBook(name, contacts, "all-contacts");
     ret.#build();

--- a/src/modules/cache/addressbook.mjs
+++ b/src/modules/cache/addressbook.mjs
@@ -30,7 +30,7 @@ export class AddressBook {
   static fromAllContacts(addressBooks, name) {
     let contacts = new Map();
     for (const ab of addressBooks) {
-      ab.contacts.forEach((contact, id) => contacts.set(id, contact));
+      ab.contacts.forEach((contact, id) => contacts.set(id, structuredClone(contact)));
     }
     let ret = new AddressBook(name, contacts, "all-contacts");
     ret.#build();

--- a/src/modules/cache/addressbook.mjs
+++ b/src/modules/cache/addressbook.mjs
@@ -7,6 +7,7 @@ import {
   SUBCATEGORY_SEPARATOR,
 } from "./index.mjs";
 import { parseContact } from "../contacts/contact.mjs";
+import { printToConsole } from "../utils.mjs";
 
 export class AddressBook {
   constructor(name, contacts, id) {
@@ -73,7 +74,7 @@ export function lookupCategory(
   getUncategorized = false
 ) {
   // Look up a category using a key like `A / B`.
-  console.log("Looking up", categoryKey);
+  printToConsole.log("Looking up", categoryKey);
   const category = categoryStringToArr(categoryKey);
   if (getUncategorized) {
     // Remove the last sub category, which is "Uncategorized". It is called, by

--- a/src/modules/cache/listeners.mjs
+++ b/src/modules/cache/listeners.mjs
@@ -102,7 +102,7 @@ async function updateCacheOnAddressBookDeletion(addressBooks, addressBookId) {
   const virtualAddressBook = addressBooks.get("all-contacts");
   for (const contactId of addressBook.contacts.keys()) {
     await deleteContactInCache(
-      null,  // We are going to delete the entire cache, so ne need to delete the contacts.
+      null,  // We are going to delete the entire cache, so no need to delete the contacts.
       virtualAddressBook, 
       contactId
     );

--- a/src/modules/cache/update.mjs
+++ b/src/modules/cache/update.mjs
@@ -7,7 +7,6 @@ import {
   Category,
   categoryStringToArr,
   categoryArrToString,
-  expandImplicitCategories,
   getParentCategoryStr,
   isSubcategoryOf,
   lookupCategory,
@@ -41,17 +40,17 @@ export async function modifyContactInCache(
 ) {
   const id = newContact.id;
   const oldContact = virtualAddressBook.contacts.get(id);
-  // Expand the categories here, to properly detect additions and deletions of
-  // categories and subcategories.
-  const newCategories = expandImplicitCategories(newContact.categories);
-  const oldCategories = expandImplicitCategories(oldContact.categories);
-  printToConsole.debug("Old categories: ", JSON.stringify([...oldCategories]));
-  printToConsole.debug("New categories: ", JSON.stringify([...newCategories]));
 
-  // Update the contact (displayName, email, categories). The individual contact
-  // object is stored by reference in all subcategories. Do not replace it, but
-  // update it and keep the same object as a container (otherwise all references
-  // will be disconnected).
+  // Cached categories include implicit categories.
+  const newCategories = [...newContact.categories];
+  const oldCategories = [...oldContact.categories];
+  printToConsole.debug("Old categories: ", JSON.stringify(oldCategories));
+  printToConsole.debug("New categories: ", JSON.stringify(newCategories));
+
+  // Update the contact (displayName, email, categories). Since the individual
+  // contact object is stored by reference in all subcategories, we update the
+  // object and keep all its references, instead of replacing it (which would
+  // remove the reference).
   Object.keys(oldContact).forEach(key => {
     delete oldContact[key];
   });

--- a/src/modules/cache/update.mjs
+++ b/src/modules/cache/update.mjs
@@ -74,6 +74,7 @@ export async function modifyContactInCache(
     oldContact[key] = newContact[key];
   });
   addressBook.contacts = sortContactsMap(addressBook.contacts);
+  virtualAddressBook.contacts = sortContactsMap(virtualAddressBook.contacts);
 }
 
 export async function deleteContactInCache(addressBook, contactId) {

--- a/src/modules/cache/update.mjs
+++ b/src/modules/cache/update.mjs
@@ -14,6 +14,7 @@ import {
   removeImplicitCategories,
   removeSubCategories,
 } from "./index.mjs";
+import { printToConsole } from "../utils.mjs";
 
 export async function createContactInCache(
   addressBook,
@@ -44,8 +45,8 @@ export async function modifyContactInCache(
   // categories and subcategories.
   const newCategories = expandImplicitCategories(newContact.categories);
   const oldCategories = expandImplicitCategories(oldContact.categories);
-  console.debug("Old categories: ", JSON.stringify([...oldCategories]));
-  console.debug("New categories: ", JSON.stringify([...newCategories]));
+  printToConsole.debug("Old categories: ", JSON.stringify([...oldCategories]));
+  printToConsole.debug("New categories: ", JSON.stringify([...newCategories]));
   if (
     newCategories.length != oldCategories.length ||
     newCategories.some((value) => !oldCategories.includes(value))
@@ -62,12 +63,12 @@ export async function modifyContactInCache(
       oldCategories.filter(o => !newCategories.includes(o))
     );
 
-    console.debug("Addition", addition);
+    printToConsole.debug("Addition", addition);
     for (const cat of addition) {
       await addCategoryToCachedContact(addressBook, id, cat);
       await addCategoryToCachedContact(virtualAddressBook, id, cat);
     }
-    console.debug("Deletion", deletion);
+    printToConsole.debug("Deletion", deletion);
     for (const cat of deletion) {
       await removeCategoryFromCachedContact(addressBook, id, cat);
       await removeCategoryFromCachedContact(virtualAddressBook, id, cat);
@@ -155,7 +156,7 @@ async function addCategoryToCachedContact(
   contactId,
   categoryStr,
 ) {
-  console.info(
+  printToConsole.info(
     "addCategoryToCachedContact",
     addressBook,
     contactId,
@@ -189,7 +190,7 @@ async function addCategoryToCachedContact(
     categoryObject.contacts.set(contactId, addressBook.contacts.get(contactId));
     categoryObject.contacts = sortContactsMap(categoryObject.contacts);
   }
-  console.info("Categories data updated: ", contact.categories);
+  printToConsole.info("Categories data updated: ", contact.categories);
 }
 
 /**
@@ -206,7 +207,7 @@ async function removeCategoryFromCachedContact(
   contactId,
   categoryStr,
 ) {
-  console.info(
+  printToConsole.info(
     "removeCategoryFromCachedContact",
     addressBook,
     contactId,
@@ -252,5 +253,5 @@ async function removeCategoryFromCachedContact(
   }
 
   recursiveRemove(parentCategoryObj, categoryStringToArr(categoryStr).pop(), contactId);
-  console.info("Categories data updated: ", contact.categories);
+  printToConsole.info("Categories data updated: ", contact.categories);
 }

--- a/src/modules/contacts/category-edit.mjs
+++ b/src/modules/contacts/category-edit.mjs
@@ -3,80 +3,43 @@
  * contacts in the Thunderbird backend.
  */
 
-import { updateCategoriesForContact } from "./contact.mjs";
+import { updateCategoriesForVCard } from "./contact.mjs";
 import {
   lookupCategory,
-  isSubcategoryOf,
-  expandImplicitCategories,
+  mergeCategory,
+  stripCategory,
 } from "../cache/index.mjs";
 
 /** 
- * Remove the contact from this category and all its subcategories.
+ * Remove a vCard from this category and all its subcategories.
  */
-export async function removeCategoryFromContactVCard({
+export async function removeCategoryFromVCard({
   contactId,
   addressBook,
   categoryStr,
 }) {
   let contact = addressBook.contacts.get(contactId);
-  // Categories in cache always include all implicit categories.
-  let newCategories = [...contact.categories].filter(
-    cat => cat != categoryStr && !isSubcategoryOf(cat, categoryStr)
-  );
-  return updateCategoriesForContact(contact, newCategories);
+  let newCategories = stripCategory([...contact.categories], categoryStr);
+  return updateCategoriesForVCard(contact, newCategories);
 }
 
-export async function addCategoryToContactVCard({
+/** 
+ * Add a vCard to this category and all its parent categories.
+ */
+export async function addCategoryToVCard({
   contactId,
   addressBook,
   categoryStr,
 }) {
   let contact = addressBook.contacts.get(contactId);
-  let newCategories = [...contact.categories];
-  for (let cat of expandImplicitCategories([categoryStr])) {
-    if (!newCategories.includes(cat)) {
-      newCategories.push(cat);
-    }
-  }
-  return updateCategoriesForContact(contact, newCategories);
-}
-/**
- * Remove an entire category by updating all affected contacts.
- */
-export async function removeCategory({
-  categoryStr,
-  addressBook,
-  addressBooks,
-}) {
-  let pendingAddressBooks = addressBook.id == "all-contacts"
-    ? addressBooks.values()
-    : [addressBook];
-    for (const ab of pendingAddressBooks) {
-      if (ab.id == "all-contacts") {
-        continue;
-      }
-      // Loop over all contacts of that category.
-      const categoryObj = lookupCategory(
-        ab,
-        categoryStr
-      );
-      if (!categoryObj) {
-        continue;
-      }
-      for (let [contactId] of categoryObj.contacts) {
-        await removeCategoryFromContactVCard({
-          contactId,
-          addressBook: ab,
-          categoryStr,
-        })
-      }
-    }
+  let newCategories = mergeCategory([...contact.categories], categoryStr);
+  return updateCategoriesForVCard(contact, newCategories);
 }
 
 /**
- * Rename/Move an entire category by updating all affected contacts.
+ * Replace a category name in all affected vCards (move/rename/remove).
  */
-export async function moveCategory({
+export async function replaceCategoryInVCards({
   addressBook,
   addressBooks,
   oldCategoryStr,
@@ -99,15 +62,9 @@ export async function moveCategory({
       continue;
     }
     for (let [contactId, contact] of categoryObj.contacts) {
-      let newCategories = [...contact.categories].filter(
-        cat => cat != oldCategoryStr && !isSubcategoryOf(cat, oldCategoryStr)
-      );
-      for (let cat of expandImplicitCategories([newCategoryStr])) {
-        if (!newCategories.includes(cat)) {
-          newCategories.push(cat);
-        }
-      }
-      await updateCategoriesForContact(contact, newCategories);
+      let newCategories = stripCategory([...contact.categories], oldCategoryStr);
+      mergeCategory(newCategories, newCategoryStr);
+      await updateCategoriesForVCard(contact, newCategories);
     }
   }
 }

--- a/src/modules/contacts/category-edit.mjs
+++ b/src/modules/contacts/category-edit.mjs
@@ -44,12 +44,11 @@ export async function removeCategory({
   addressBook,
   addressBooks,
 }) {
-  const virtualAddressBook = addressBooks.get("all-contacts");
-  let pendingAddressBooks = addressBook === virtualAddressBook
+  let pendingAddressBooks = addressBook.id == "all-contacts"
     ? addressBooks.values()
     : [addressBook];
     for (const ab of pendingAddressBooks) {
-      if (ab == virtualAddressBook) {
+      if (ab.id == "all-contacts") {
         continue;
       }
       // Loop over all contacts of that category.
@@ -79,13 +78,12 @@ export async function moveCategory({
   oldCategoryStr,
   newCategoryStr,
 }) {
-  const virtualAddressBook = addressBooks.get("all-contacts");
-  let pendingAddressBooks = addressBook === virtualAddressBook
+  let pendingAddressBooks = addressBook.id == "all-contacts"
     ? addressBooks.values()
     : [addressBook];
 
   for (const ab of pendingAddressBooks) {
-    if (ab == virtualAddressBook) {
+    if (ab.id == "all-contacts") {
       continue;
     }
     // Loop over all contacts of that category.

--- a/src/modules/contacts/contact.mjs
+++ b/src/modules/contacts/contact.mjs
@@ -6,9 +6,8 @@
 import {
   removeImplicitCategories,
   expandImplicitCategories,
-  isSubcategoryOf,
 } from "../cache/index.mjs";
-import { setEqual, printToConsole } from "../utils.mjs";
+import { arrayEqual, printToConsole } from "../utils.mjs";
 // global object: ICAL from external ical.js
 
 const ERR_OPERATION_CANCEL = await browser.i18n.getMessage(
@@ -45,47 +44,41 @@ export function getError(str, id) {
  * Modify the category string of a contacts vcard.
  * 
  * @param {*} contact - contact to work on
- * @param {array} addition - categories to add
- * @param {array} deletion - categories to remove (including all subcategories)
+ * @param {array} categories - new categories
  */
-export async function updateCategoriesForContact(contact, addition, deletion) {
+export async function updateCategoriesForContact(contact, categories) {
   const {
     properties: { vCard },
   } = await browser.contacts.get(contact.id);
   const component = new ICAL.Component(ICAL.parse(vCard));
-  const oldCategories = new Set(
+
+  const newCategories = removeImplicitCategories(categories)
+  const cachedCategories = removeImplicitCategories([...contact.categories]);
+  const backendCategories = removeImplicitCategories(
     component.getAllProperties("categories").flatMap((x) => x.getValues())
   );
-  const oldCategoriesFromInput = contact.categories;
-  if (!setEqual(oldCategories, oldCategoriesFromInput)) {
+
+  if (!arrayEqual(backendCategories, cachedCategories)) {
     printToConsole.error("Categories have been changed outside category manager!");
-    printToConsole.log("Old Categories", structuredClone(oldCategories));
-    printToConsole.log(
-      "Old Categories From Input",
-      structuredClone(oldCategoriesFromInput)
-    );
+    printToConsole.log("Currently stored categories", structuredClone(backendCategories));
+    printToConsole.log("Currently cached categories", structuredClone(cachedCategories));
     throw getError(ERR_OPCANCEL_UPDATE_FAILURE, 2);
   }
 
-  let newCategories = [...oldCategories].filter(
-    x => !deletion.find(d => x == d || isSubcategoryOf(x, d))
-  );
-  newCategories = removeImplicitCategories(
-    [...newCategories, ...addition.filter(a => a != null)]
-  );
-
-  if (
-    newCategories.length === oldCategories.size &&
-    newCategories.every((x) => oldCategories.has(x))
-  ) {
+  if (arrayEqual(backendCategories, newCategories)) {
     // No change, return
     printToConsole.warn("No change made to the vCard!");
     return;
   }
+
+  // Store new categories.
   component.removeAllProperties("categories");
-  for (const cat of newCategories) {
-    component.addPropertyWithValue("categories", cat);
+  if (newCategories.length > 0) {
+    var categoriesProperty = new ICAL.Property("categories");
+    categoriesProperty.setValues(newCategories);
+    component.addProperty(categoriesProperty);
   }
+
   const newVCard = component.toString();
   printToConsole.log("new vCard:", newVCard);
   try {

--- a/src/modules/contacts/contact.mjs
+++ b/src/modules/contacts/contact.mjs
@@ -41,12 +41,12 @@ export function getError(str, id) {
 }
 
 /**
- * Modify the category string of a contacts vcard.
+ * Modify the category string of a vCard.
  * 
  * @param {*} contact - contact to work on
  * @param {array} categories - new categories
  */
-export async function updateCategoriesForContact(contact, categories) {
+export async function updateCategoriesForVCard(contact, categories) {
   const {
     properties: { vCard },
   } = await browser.contacts.get(contact.id);

--- a/src/modules/contacts/contact.mjs
+++ b/src/modules/contacts/contact.mjs
@@ -7,7 +7,7 @@ import {
   removeImplicitCategories,
   isSubcategoryOf,
 } from "../cache/index.mjs";
-import { setEqual } from "../set.mjs";
+import { setEqual, printToConsole } from "../utils.mjs";
 // global object: ICAL from external ical.js
 
 const ERR_OPERATION_CANCEL = await browser.i18n.getMessage(
@@ -57,9 +57,9 @@ export async function updateCategoriesForContact(contact, addition, deletion) {
   );
   const oldCategoriesFromInput = contact.categories;
   if (!setEqual(oldCategories, oldCategoriesFromInput)) {
-    console.error("Categories have been changed outside category manager!");
-    console.log("Old Categories", structuredClone(oldCategories));
-    console.log(
+    printToConsole.error("Categories have been changed outside category manager!");
+    printToConsole.log("Old Categories", structuredClone(oldCategories));
+    printToConsole.log(
       "Old Categories From Input",
       structuredClone(oldCategoriesFromInput)
     );
@@ -78,7 +78,7 @@ export async function updateCategoriesForContact(contact, addition, deletion) {
     newCategories.every((x) => oldCategories.has(x))
   ) {
     // No change, return
-    console.warn("No change made to the vCard!");
+    printToConsole.warn("No change made to the vCard!");
     return;
   }
   component.removeAllProperties("categories");
@@ -86,11 +86,11 @@ export async function updateCategoriesForContact(contact, addition, deletion) {
     component.addPropertyWithValue("categories", cat);
   }
   const newVCard = component.toString();
-  console.log("new vCard:", newVCard);
+  printToConsole.log("new vCard:", newVCard);
   try {
     await browser.contacts.update(contact.id, { vCard: newVCard });
   } catch (e) {
-    console.error("Error when updating contact: ", e);
+    printToConsole.error("Error when updating contact: ", e);
     throw getError(ERR_OPCANCEL_UPDATE_FAILURE, 1);
   }
   return null;

--- a/src/modules/contacts/contact.mjs
+++ b/src/modules/contacts/contact.mjs
@@ -5,6 +5,7 @@
 
 import {
   removeImplicitCategories,
+  expandImplicitCategories,
   isSubcategoryOf,
 } from "../cache/index.mjs";
 import { setEqual, printToConsole } from "../utils.mjs";
@@ -102,9 +103,10 @@ export function parseContact({
   properties: { vCard, DisplayName },
 }) {
   const component = new ICAL.Component(ICAL.parse(vCard));
-  const categories = component
+  const categories = expandImplicitCategories(component
     .getAllProperties("categories")
-    .flatMap((x) => x.getValues());
+    .flatMap((x) => x.getValues())
+  );
   return {
     id,
     addressBookId: parentId,

--- a/src/modules/set.mjs
+++ b/src/modules/set.mjs
@@ -1,8 +1,0 @@
-export function setEqual(xs, ys) {
-  return xs.size === ys.size && [...xs].every((x) => ys.has(x));
-}
-
-// Set intersection for ES6 Set.
-export function setIntersection(a, b) {
-  return new Set([...a].filter((x) => b.has(x)));
-}

--- a/src/modules/ui/context-menu-utils.mjs
+++ b/src/modules/ui/context-menu-utils.mjs
@@ -3,6 +3,7 @@ import {
   isContactInCategory,
   isContactInAnySubcategory,
 } from "../cache/index.mjs";
+import { printToConsole } from "../utils.mjs";
 
 let { type } = await browser.windows.getCurrent();
 const MENU_TITLE_LOCALE_KEY =
@@ -162,10 +163,10 @@ export function createDispatcherForContactListContextMenu({
         await onAddition(categoryStr, false);
         break;
       case "#":
-        console.error("This menu item should not be clickable!");
+        printToConsole.error("This menu item should not be clickable!");
         break;
       default:
-        console.error("Unknown menu id:", menuId);
+        printToConsole.error("Unknown menu id:", menuId);
         break;
     }
   };

--- a/src/modules/ui/context-menu-utils.mjs
+++ b/src/modules/ui/context-menu-utils.mjs
@@ -1,7 +1,9 @@
+import { lookupCategory } from "../cache/addressbook.mjs";
 import {
-  SUBCATEGORY_SEPARATOR,
+  categoryStringToArr,
   isContactInCategory,
   isContactInAnySubcategory,
+  SUBCATEGORY_SEPARATOR,
 } from "../cache/index.mjs";
 import { printToConsole } from "../utils.mjs";
 
@@ -69,7 +71,7 @@ export function createMenuForCategoryTree(categoryElement) {
     id: "addToBCC",
     title: MENU_ADD_TO_BCC,
   });
-  if (!("uncategorized" in categoryElement.dataset)) {
+  if (!categoryElement.dataset.uncategorized) {
     // Add an option to delete this category
     createSeparator();
     createMenu({ id: "renameCategory", title: MENU_RENAME_CATEGORY });
@@ -153,6 +155,7 @@ export function createDispatcherForContactListContextMenu({
   return async function (menuId) {
     const categoryStr = menuId.slice(1);
     switch (menuId.charAt(0)) {
+      case "!":
       case "@":
         await onDeletion(categoryStr);
         break;
@@ -172,7 +175,7 @@ export function createDispatcherForContactListContextMenu({
   };
 }
 
-export async function createMenuForContact(addressBook, contactId) {
+export async function createMenuForContact(addressBook, contactId, categoryElm) {
   // Symbols:
   //    @: remove from category
   //    #: normal category
@@ -187,6 +190,19 @@ export async function createMenuForContact(addressBook, contactId) {
     title: MENU_HEADER_TEXT,
     enabled: false,
   });
+
+
+  if (categoryElm && categoryElm.dataset.category && !categoryElm.dataset.uncategorized) {
+    let categoryStr = categoryElm.dataset.category;
+    let categoryObj = lookupCategory(addressBook, categoryStr);
+    let remove_string_key = isContactInAnySubcategory(categoryObj, contactId)
+      ? "menu.contact.context.remove_from_category_recursively"
+      : "menu.contact.context.remove_from_category";
+    createMenu({
+      id: "!" + categoryStr,
+      title: await browser.i18n.getMessage(remove_string_key, categoryStringToArr(categoryStr).pop()),
+    });
+  }
 
   if (addressBook.categories.size > 0) {
     createSeparator();

--- a/src/modules/utils.mjs
+++ b/src/modules/utils.mjs
@@ -7,6 +7,10 @@ export function setIntersection(a, b) {
   return new Set([...a].filter((x) => b.has(x)));
 }
 
+export function arrayEqual(a, b) {
+  return a.length === b.length && a.every(val => b.includes(val));
+}
+
 async function initLog() {
   let { logToConsole } = await browser.storage.local.get( { logToConsole: null });
   // Set a default so it can be toggled via the add-on inspector storage tab.

--- a/src/modules/utils.mjs
+++ b/src/modules/utils.mjs
@@ -1,0 +1,42 @@
+export function setEqual(xs, ys) {
+  return xs.size === ys.size && [...xs].every((x) => ys.has(x));
+}
+
+// Set intersection for ES6 Set.
+export function setIntersection(a, b) {
+  return new Set([...a].filter((x) => b.has(x)));
+}
+
+async function initLog() {
+  let { logToConsole } = await browser.storage.local.get( { logToConsole: null });
+  // Set a default so it can be toggled via the add-on inspector storage tab.
+  if (logToConsole == null) {
+    logToConsole = false;
+    await browser.storage.local.set( { logToConsole });
+  }
+  window.logToConsole = logToConsole;
+  console.info(`CategoryManager.logToConsole is set to ${logToConsole}`);
+}
+
+function printLog(type, ...args) {
+  if (window.logToConsole) {
+    console[type](...args);
+  }
+}
+
+function _printToConsole(type, ...args) {
+  // This function is synchronous but returns a Promise when called the first
+  // time in a given window, which fulfills once the storage has been read.
+  if (!window.hasOwnProperty("logToConsole")) {
+    return initLog().then(() => printLog(type, ...args));
+  }
+  return printLog(type, ...args);
+}
+
+export const printToConsole = {
+  debug: (...args) => _printToConsole("debug", ...args),
+  error: (...args) => _printToConsole("error", ...args),
+  info: (...args) => _printToConsole("info", ...args),
+  log: (...args) => _printToConsole("log", ...args),
+  warn: (...args) => _printToConsole("warn", ...args),
+}

--- a/src/popup/category-tree.mjs
+++ b/src/popup/category-tree.mjs
@@ -8,6 +8,7 @@ import {
   buildUncategorizedCategory,
   hasSubcategories,
 } from "../modules/cache/index.mjs";
+import { printToConsole } from "../modules/utils.mjs";
 import { lookupContactsByCategoryElement } from "./utils.mjs";
 import {
   addContactsToComposeDetails,
@@ -183,7 +184,7 @@ export function createCategoryTree({
       // further subcategories)
       state.currentDraggingOverCategoryElement = e.target.children[0];
     } else if (e.target.nodeName === "DETAILS") {
-      console.warn("Dragging over details!");
+      printToConsole.warn("Dragging over details!");
       return;
     } else {
       state.currentDraggingOverCategoryElement = e.target;
@@ -198,7 +199,7 @@ export function createCategoryTree({
         ? "none"
         : "copy";
 
-    console.warn(`Dragging onto`, state.currentDraggingOverCategoryElement);
+    printToConsole.warn(`Dragging onto`, state.currentDraggingOverCategoryElement);
     e.preventDefault();
   }
   async function dragDrop(e) {
@@ -209,7 +210,7 @@ export function createCategoryTree({
     });
     const item = e.dataTransfer.items[0];
     if (item.type !== "category-manager/contact") {
-      console.error("Invalid item for drag and drop: ", item);
+      printToConsole.error("Invalid item for drag and drop: ", item);
       return;
     }
     item.getAsString((x) => (state.currentContactDataFromDragAndDrop = x));

--- a/src/popup/category-tree.mjs
+++ b/src/popup/category-tree.mjs
@@ -26,7 +26,7 @@ function isActiveCategory(category, activeCategory) {
 
 function writeTreeLeaf(category, activeCategory) {
   let uncategorizedAttr = category.isUncategorized
-    ? 'data-uncategorized=""'
+    ? 'data-uncategorized="true"'
     : "";
   const activeClass = isActiveCategory(category, activeCategory)
     ? "active"
@@ -54,7 +54,7 @@ export function writeTreeNode(category, activeCategory) {
     );
   }
   if (!hasSubcategories(category)) return writeTreeLeaf(category, activeCategory);
-  
+
   const activeClass = isActiveCategory(category, activeCategory)
     ? "active"
     : "";
@@ -166,7 +166,7 @@ export function createCategoryTree({
     }
     window.close();
   }
-  
+
   // See https://stackoverflow.com/questions/7110353/html5-dragleave-fired-when-hovering-a-child-element
   let dragEnterLeaveCounter = 0;
   function dragEnter(e) {
@@ -195,7 +195,7 @@ export function createCategoryTree({
     state.currentDraggingOverCategoryElement.classList.add("drag-over");
     // Do not allow dragging onto uncategorized because it's not a real category.
     e.dataTransfer.dropEffect =
-      "uncategorized" in state.currentDraggingOverCategoryElement.dataset
+      !!state.currentDraggingOverCategoryElement.dataset.uncategorized
         ? "none"
         : "copy";
 

--- a/src/popup/context-menu.mjs
+++ b/src/popup/context-menu.mjs
@@ -55,7 +55,8 @@ async function overrideMenuForContactList() {
   destroyAllMenus();
   await createMenuForContact(
     state.currentAddressBook,
-    state.elementForContextMenu.dataset.id
+    state.elementForContextMenu.dataset.id,
+    state.currentCategoryElement,
   );
 }
 

--- a/src/popup/context-menu.mjs
+++ b/src/popup/context-menu.mjs
@@ -19,10 +19,9 @@ import {
   showCategoryInputModalAsync,
 } from "./modal.mjs";
 import {
-  addCategoryToContactVCard,
-  moveCategory,
-  removeCategory,
-  removeCategoryFromContactVCard,
+  addCategoryToVCard,
+  replaceCategoryInVCards,
+  removeCategoryFromVCard,
 } from "../modules/contacts/category-edit.mjs";
 
 function makeCategoryMenuHandler(fieldName) {
@@ -67,17 +66,18 @@ export function initContextMenu() {
     addToCC: makeCategoryMenuHandler("cc"),
     addToBCC: makeCategoryMenuHandler("bcc"),
     async deleteCategory(categoryElement) {
-      await removeCategory({
-        categoryStr: categoryElement.dataset.category,
+      await replaceCategoryInVCards({
         addressBook: state.currentAddressBook,
         addressBooks: state.addressBooks,
+        oldCategoryStr: categoryElement.dataset.category,
+        newCategoryStr: "",
       });
     },
     async renameCategory(categoryElement) {
       const oldCategoryStr = categoryElement.dataset.category;
       const newCategoryStr = await showCategoryInputModalAsync(oldCategoryStr);
       if (newCategoryStr == null) return;
-      await moveCategory({
+      await replaceCategoryInVCards({
         addressBook: state.currentAddressBook,
         addressBooks: state.addressBooks,
         oldCategoryStr,
@@ -91,7 +91,7 @@ export function initContextMenu() {
         const contactId = state.elementForContextMenu.dataset.id;
         const addressBookId = state.elementForContextMenu.dataset.addressbook;
         const addressBook = state.addressBooks.get(addressBookId);
-        await removeCategoryFromContactVCard({
+        await removeCategoryFromVCard({
           addressBook,
           contactId,
           categoryStr,
@@ -106,7 +106,7 @@ export function initContextMenu() {
           if (subcategory == null) return;
           categoryStr = subcategory;
         }
-        await addCategoryToContactVCard({
+        await addCategoryToVCard({
           addressBook,
           contactId,
           categoryStr,

--- a/src/popup/context-menu.mjs
+++ b/src/popup/context-menu.mjs
@@ -3,6 +3,7 @@
 // -------------------
 
 import { createDispatcherForContactListContextMenu } from "../modules/ui/context-menu-utils.mjs";
+import { printToConsole } from "../modules/utils.mjs";
 import {
   addContactsToComposeDetails,
   openComposeWindowWithContacts,
@@ -120,7 +121,7 @@ export function initContextMenu() {
     }
     browser.menus.overrideContext({ context: "tab", tabId: state.tab.id });
     state.elementForContextMenu = e.target;
-    console.log(state.elementForContextMenu);
+    printToConsole.log(state.elementForContextMenu);
     // Check if the right click originates from contact list
     if (state.elementForContextMenu.parentNode.dataset.id != null) {
       // Right click on contact info

--- a/src/popup/drag-menu.mjs
+++ b/src/popup/drag-menu.mjs
@@ -2,7 +2,7 @@
 // Custom Context Menu for drag and drop on category tree
 // -------------------------------------------------------
 
-import { setIntersection } from "../modules/set.mjs";
+import { printToConsole, setIntersection } from "../modules/utils.mjs";
 import { getCategoryStringFromInput } from "./modal.mjs";
 import { addCategoryToContactVCard } from "../modules/contacts/category-edit.mjs";
 
@@ -83,7 +83,7 @@ export function initCustomMenu(categoryTree) {
   });
   customMenu.addEventListener("click", async (e) => {
     if (state.currentContactDataFromDragAndDrop == null) {
-      console.error("No contact info from drag & drop!");
+      printToConsole.error("No contact info from drag & drop!");
       return;
     }
     let categoryStr;
@@ -118,7 +118,7 @@ export function initCustomMenu(categoryTree) {
           });
           break;
         default:
-          console.error("Unknown action! from", e.target);
+          printToConsole.error("Unknown action! from", e.target);
           break;
       }
       state.currentContactDataFromDragAndDrop = null;

--- a/src/popup/drag-menu.mjs
+++ b/src/popup/drag-menu.mjs
@@ -4,7 +4,7 @@
 
 import { printToConsole, setIntersection } from "../modules/utils.mjs";
 import { getCategoryStringFromInput } from "./modal.mjs";
-import { addCategoryToContactVCard } from "../modules/contacts/category-edit.mjs";
+import { addCategoryToVCard } from "../modules/contacts/category-edit.mjs";
 
 const customMenu = document.getElementById("custom-menu");
 
@@ -100,7 +100,7 @@ export function initCustomMenu(categoryTree) {
             state.currentDraggingOverCategoryElement.dataset.category ??
             (await getCategoryStringFromInput());
           if (categoryStr == null) break;
-          await addCategoryToContactVCard({
+          await addCategoryToVCard({
             addressBook,
             contactId,
             categoryStr
@@ -111,7 +111,7 @@ export function initCustomMenu(categoryTree) {
             state.currentDraggingOverCategoryElement.dataset.category
           );
           if (categoryStr == null) break;
-          await addCategoryToContactVCard({
+          await addCategoryToVCard({
             addressBook,
             contactId,
             categoryStr

--- a/src/popup/modal.mjs
+++ b/src/popup/modal.mjs
@@ -6,6 +6,7 @@ import {
   SUBCATEGORY_SEPARATOR,
   validateCategoryString,
 } from "../modules/cache/index.mjs";
+import { printToConsole } from "../modules/utils.mjs";
 
 const categoryInput = document.getElementById("category-input");
 const categoryInputError = document.getElementById("category-input-error");
@@ -65,8 +66,8 @@ export async function getCategoryStringFromInput(parentCategory = null) {
   const result = await showCategoryInputModalAsync(
     parentCategory ? parentCategory + SUBCATEGORY_SEPARATOR : null
   );
-  console.log(categoryInput);
-  console.log(result);
+  printToConsole.log(categoryInput);
+  printToConsole.log(result);
   return result;
 }
 

--- a/src/popup/popup.mjs
+++ b/src/popup/popup.mjs
@@ -1,3 +1,4 @@
+import { printToConsole } from "../modules/utils.mjs"
 import { createContactList } from "./contact-list.mjs";
 import { createCategoryTree } from "./category-tree.mjs";
 import { createAddressBookList } from "./address-book-list.mjs";
@@ -8,6 +9,7 @@ import { initModal } from "./modal.mjs";
 import State from "./state.mjs";
 import { registerCacheUpdateCallback } from "../modules/cache/listeners.mjs";
 import { initErrorHandler } from "./error-handler.mjs";
+
 // global object: emailAddresses, ICAL, MicroModal from popup.html
 
 initErrorHandler();
@@ -17,6 +19,10 @@ initErrorHandler();
 const state = new State();
 window.state = state;
 await state.init();
+
+// This needs to be awaited only once, all following calls in this window are
+// synchronous.
+await printToConsole.log(state.addressBooks);
 
 // i18n
 document.getElementById("info-text").innerText = await browser.i18n.getMessage(
@@ -71,7 +77,7 @@ async function updateUI() {
     addressBooks: [...state.addressBooks.values()],
     activeAddressBookId: state.currentAddressBook.id,
   });
-  console.log("Active category:", state.currentCategoryElement);
+  printToConsole.log("Active category:", state.currentCategoryElement);
   await categoryTree.update({
     addressBook: state.currentAddressBook,
     activeCategory:
@@ -84,7 +90,7 @@ async function updateUI() {
         : null,
   });
   let activeElement = document.getElementsByClassName("active")[0];
-  console.log("Active Element after UI update:", activeElement);
+  printToConsole.log("Active Element after UI update:", activeElement);
   let contacts;
   if (activeElement != null) {
     state.currentCategoryElement = activeElement;

--- a/src/popup/popup.mjs
+++ b/src/popup/popup.mjs
@@ -83,10 +83,9 @@ async function updateUI() {
     activeCategory:
       state.currentCategoryElement != null
         ? {
-            path: state.currentCategoryElement.dataset.category,
-            isUncategorized:
-              "uncategorized" in state.currentCategoryElement.dataset,
-          }
+          path: state.currentCategoryElement.dataset.category,
+          isUncategorized: !!state.currentCategoryElement.dataset.uncategorized,
+        }
         : null,
   });
   let activeElement = document.getElementsByClassName("active")[0];

--- a/src/popup/state.mjs
+++ b/src/popup/state.mjs
@@ -16,7 +16,6 @@ class State {
     this.#tab = tab;
     const { addressBooks } = await browser.storage.local.get("addressBooks");
     this.addressBooks = addressBooks;
-    console.log(addressBooks);
     this.allContactsVirtualAddressBook = this.addressBooks.get("all-contacts");
     this.currentAddressBook = this.allContactsVirtualAddressBook;
     if (this.currentAddressBook == null)

--- a/src/popup/utils.mjs
+++ b/src/popup/utils.mjs
@@ -3,7 +3,7 @@ import { lookupCategory } from "../modules/cache/addressbook.mjs";
 export function lookupContactsByCategoryElement(element, addressBook) {
   // Find contacts by an category html element.
   const categoryKey = element.dataset.category;
-  const isUncategorized = element.dataset.uncategorized != null;
+  const isUncategorized = !!element.dataset.uncategorized;
   return lookupCategory(addressBook, categoryKey, isUncategorized)
     .contacts;
 }


### PR DESCRIPTION
We should create a clone of the contact when creating the all-contacts address book because we intend to update them separately. It will become a footgun that is hard to debug if the virtual addressbook and real addressbook is referencing the same contact object.